### PR TITLE
simplify cds-plugin export

### DIFF
--- a/cds-plugin.js
+++ b/cds-plugin.js
@@ -27,6 +27,4 @@ const activate = async () => {
   }
 };
 
-module.exports = {
-  activate,
-};
+module.exports = activate;


### PR DESCRIPTION
The plugin mechanism is able to deal with asynchronous functions. Daniel would like to get rid of the `activate` function in general. This PR would already prepare for it.