### PR TITLE
Fix/cds 7 3 0 breaking api

### DIFF
--- a/cds-plugin.js
+++ b/cds-plugin.js
@@ -2,7 +2,12 @@
 "use strict";
 
 const cds = require("@sap/cds");
+const cdsPackage = require("@sap/cds/package.json");
 const { initializeFeatures } = require("./src/singleton");
+
+// NOTE: for sap/cds < 7.3.0 it was expected to export activate as property,
+const doExportActivateAsProperty =
+  cdsPackage.version.localeCompare("7.3.0", undefined, { numeric: true, sensitivity: "base" }) < 0;
 
 const activate = async () => {
   const envFeatureToggles = cds.env.featureToggles;
@@ -27,6 +32,8 @@ const activate = async () => {
   }
 };
 
-module.exports = {
-  activate,
-};
+module.exports = doExportActivateAsProperty
+  ? {
+      activate,
+    }
+  : activate;

--- a/cds-plugin.js
+++ b/cds-plugin.js
@@ -5,10 +5,6 @@ const cds = require("@sap/cds");
 const cdsPackage = require("@sap/cds/package.json");
 const { initializeFeatures } = require("./src/singleton");
 
-// NOTE: for sap/cds < 7.3.0 it was expected to export activate as property,
-const doExportActivateAsProperty =
-  cdsPackage.version.localeCompare("7.3.0", undefined, { numeric: true, sensitivity: "base" }) < 0;
-
 const activate = async () => {
   const envFeatureToggles = cds.env.featureToggles;
   if (envFeatureToggles?.config || envFeatureToggles?.configFile) {
@@ -31,6 +27,11 @@ const activate = async () => {
     });
   }
 };
+
+// NOTE: for sap/cds < 7.3.0 it was expected to export activate as function property, otherwise export the promise of
+//   running activate
+const doExportActivateAsProperty =
+  cdsPackage.version.localeCompare("7.3.0", undefined, { numeric: true, sensitivity: "base" }) < 0;
 
 module.exports = doExportActivateAsProperty
   ? {

--- a/cds-plugin.js
+++ b/cds-plugin.js
@@ -36,4 +36,4 @@ module.exports = doExportActivateAsProperty
   ? {
       activate,
     }
-  : activate;
+  : activate();

--- a/example-cap-server/package.json
+++ b/example-cap-server/package.json
@@ -20,11 +20,11 @@
   },
   "dependencies": {
     "@cap-js-community/feature-toggle-library": "*",
-    "@sap/cds": "^7.2.0",
+    "@sap/cds": "^7.3.0",
     "express": "^4.18.2"
   },
   "devDependencies": {
-    "@sap/cds-dk": "^7.2.0"
+    "@sap/cds-dk": "^7.3.0"
   },
   "cds": {
     "featureToggles": {


### PR DESCRIPTION
Similar to #31 with the two additional changes

- export promise not function as required by 7.3.0 coding
- add a version check, so cds versions < 7.3.0 will still work with the plugin
