### PR TITLE
unify and fix syntax of context.error and context.reject for cds service

### DIFF
--- a/src/service/feature-service.js
+++ b/src/service/feature-service.js
@@ -75,7 +75,7 @@ const redisUpdateHandler = async (context) => {
       if (Array.isArray(validationErrors) && validationErrors.length > 0) {
         for (const { featureKey: target, errorMessage, errorMessageValues } of validationErrors) {
           const errorMessageWithValues = textFormat(errorMessage, errorMessageValues);
-          context.error(VALIDATION_ERROR_HTTP_CODE, { message: errorMessageWithValues }, [], target);
+          context.error({ code: VALIDATION_ERROR_HTTP_CODE, message: errorMessageWithValues, target });
         }
       }
     };
@@ -97,14 +97,14 @@ const redisUpdateHandler = async (context) => {
         "error during redis update"
       )
     );
-    context.reject(500, { message: "caught unexpected error during redis update, check server logs" });
+    context.reject({ code: 500, message: "caught unexpected error during redis update, check server logs" });
   }
 };
 
 const redisSendCommandHandler = async (context) => {
   const { command } = context.data;
   if (!Array.isArray(command)) {
-    context.reject(400, { message: "request body needs to contain a 'command' field of type array" });
+    context.reject({ code: 400, message: "request body needs to contain a 'command' field of type array" });
     return;
   }
   const result = await redis.sendCommand(command);

--- a/src/service/feature-service.js
+++ b/src/service/feature-service.js
@@ -45,7 +45,7 @@ const redisReadHandler = async (context) => {
         "error during redis read"
       )
     );
-    context.reject(500, { message: "caught unexpected error during redis read, check server logs" });
+    context.reject({ code: 500, message: "caught unexpected error during redis read, check server logs" });
   }
 };
 
@@ -107,8 +107,9 @@ const redisSendCommandHandler = async (context) => {
     context.reject({ code: 400, message: "request body needs to contain a 'command' field of type array" });
     return;
   }
-  const result = await redis.sendCommand(command);
-  context.reply(typeof result === "string" ? result : JSON.stringify(result));
+  const redisResponse = await redis.sendCommand(command);
+  const result = typeof redisResponse === "string" ? redisResponse : JSON.stringify(redisResponse);
+  context.reply(result);
 };
 
 module.exports = async (srv) => {


### PR DESCRIPTION
See
https://cap.cloud.sap/docs/node.js/events#req-reject
https://cap.cloud.sap/docs/node.js/events#req-error
