### PR TITLE
Fb/better change handling

### DIFF
--- a/src/featureToggles.js
+++ b/src/featureToggles.js
@@ -1231,6 +1231,7 @@ class FeatureToggles {
   /**
    * Handler for refresh message.
    */
+  // TODO rewrite, try catch should be inside so that all entries are always processed.
   async _messageHandler(message) {
     let featureKey, newValue, scopeMap, options;
     try {

--- a/src/featureToggles.js
+++ b/src/featureToggles.js
@@ -1251,7 +1251,22 @@ class FeatureToggles {
     await Promise.all(
       changeEntries.map(async (changeEntry) => {
         try {
+          if (!isObject(changeEntry) || changeEntry.featureKey === undefined || changeEntry.newValue === undefined) {
+            logger.warning(
+              new VError(
+                {
+                  name: VERROR_CLUSTER_NAME,
+                  info: {
+                    changeEntry: JSON.stringify(changeEntry),
+                  },
+                },
+                "received and ignored change entry"
+              )
+            );
+            return;
+          }
           const { featureKey, newValue, scopeMap, options } = changeEntry;
+
           const scopeKey = FeatureToggles.getScopeKey(scopeMap);
           const oldValue = FeatureToggles._getFeatureValueForScopeAndStateAndFallback(
             this.__superScopeCache,

--- a/src/featureToggles.js
+++ b/src/featureToggles.js
@@ -1228,7 +1228,7 @@ class FeatureToggles {
   }
 
   /**
-   * Handler for refresh message.
+   * Handler for message with change entries.
    */
   async _messageHandler(message) {
     const changeEntries = FeatureToggles._deserializeChangesFromRefreshMessage(message);
@@ -1250,9 +1250,8 @@ class FeatureToggles {
 
     await Promise.all(
       changeEntries.map(async (changeEntry) => {
-        let featureKey, newValue, scopeMap, options;
         try {
-          ({ featureKey, newValue, scopeMap, options } = changeEntry);
+          const { featureKey, newValue, scopeMap, options } = changeEntry;
           const scopeKey = FeatureToggles.getScopeKey(scopeMap);
           const oldValue = FeatureToggles._getFeatureValueForScopeAndStateAndFallback(
             this.__superScopeCache,
@@ -1299,7 +1298,6 @@ class FeatureToggles {
                 info: {
                   channel: this.__redisChannel,
                   changeEntry: JSON.stringify(changeEntry),
-                  ...(featureKey && { featureKey }),
                 },
               },
               "error during message handling"

--- a/src/featureToggles.js
+++ b/src/featureToggles.js
@@ -1257,6 +1257,7 @@ class FeatureToggles {
                 {
                   name: VERROR_CLUSTER_NAME,
                   info: {
+                    channel: this.__redisChannel,
                     changeEntry: JSON.stringify(changeEntry),
                   },
                 },

--- a/src/featureToggles.js
+++ b/src/featureToggles.js
@@ -1233,8 +1233,21 @@ class FeatureToggles {
   async _messageHandler(message) {
     const changeEntries = FeatureToggles._deserializeChangesFromRefreshMessage(message);
     if (!Array.isArray(changeEntries)) {
+      logger.error(
+        new VError(
+          {
+            name: VERROR_CLUSTER_NAME,
+            info: {
+              channel: this.__redisChannel,
+              message,
+            },
+          },
+          "error during message deserialization"
+        )
+      );
       return;
     }
+
     await Promise.all(
       changeEntries.map(async (changeEntry) => {
         let featureKey, newValue, scopeMap, options;

--- a/src/featureToggles.js
+++ b/src/featureToggles.js
@@ -1285,9 +1285,8 @@ class FeatureToggles {
                 cause: err,
                 info: {
                   channel: this.__redisChannel,
-                  message,
+                  changeEntry: JSON.stringify(changeEntry),
                   ...(featureKey && { featureKey }),
-                  ...(scopeMap && { scopeMap: JSON.stringify(scopeMap) }),
                 },
               },
               "error during message handling"

--- a/src/featureToggles.js
+++ b/src/featureToggles.js
@@ -1257,7 +1257,6 @@ class FeatureToggles {
                 {
                   name: VERROR_CLUSTER_NAME,
                   info: {
-                    channel: this.__redisChannel,
                     changeEntry: JSON.stringify(changeEntry),
                   },
                 },

--- a/src/shared/static.js
+++ b/src/shared/static.js
@@ -28,6 +28,12 @@ const tryRequire = (module) => {
   } catch (err) {} // eslint-disable-line no-empty
 };
 
+const tryJsonParse = (...args) => {
+  try {
+    return JSON.parse(...args);
+  } catch (err) {} // eslint-disable-line no-empty
+};
+
 const pathReadable = async (path) => (await accessAsync(path, fs.constants.R_OK)) ?? true;
 
 const tryPathReadable = async (path) => {
@@ -43,6 +49,7 @@ module.exports = {
   isNull,
   isObject,
   tryRequire,
+  tryJsonParse,
   pathReadable,
   tryPathReadable,
 };

--- a/test/__snapshots__/featureToggles.test.js.snap
+++ b/test/__snapshots__/featureToggles.test.js.snap
@@ -218,9 +218,3 @@ exports[`feature toggles test basic apis initializeFeatureToggles warns for inva
   },
 }
 `;
-
-exports[`feature toggles test basic apis initializeFeatureToggles warns for invalid values 3`] = `
-{
-  "validationErrors": "[{"featureKey":"test/feature_b","errorMessage":"value null is not allowed"},{"featureKey":"test/feature_c","errorMessage":"value \\"{0}\\" has invalid type {1}, must be {2}","errorMessageValues":["1","string","number"]}]",
-}
-`;

--- a/test/featureToggles.test.js
+++ b/test/featureToggles.test.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const util = require("util");
+
 const VError = require("verror");
 const yaml = require("yaml");
 const featureTogglesModule = require("../src/featureToggles");
@@ -24,6 +26,8 @@ jest.mock("../src/shared/env", () => require("./__mocks__/env"));
 
 const redisWrapperMock = require("../src/redisWrapper");
 jest.mock("../src/redisWrapper", () => require("./__mocks__/redisWrapper"));
+
+const outputFromErrorLogger = (calls) => util.format("%s\n%O", calls[0][0], VError.info(calls[0][0]));
 
 const configToFallbackValues = (config) =>
   Object.fromEntries(Object.entries(config).map(([key, { fallbackValue }]) => [key, fallbackValue]));
@@ -131,16 +135,12 @@ describe("feature toggles test", () => {
         `[]`
       );
       expect(loggerSpy.error).toHaveBeenCalledTimes(1);
-      expect(loggerSpy.error.mock.calls[0]).toMatchInlineSnapshot(`
-        [
-          [FeatureTogglesError: scope exceeds allowed number of keys],
-        ]
-      `);
-      expect(VError.info(loggerSpy.error.mock.calls[0][0])).toMatchInlineSnapshot(`
+      expect(outputFromErrorLogger(loggerSpy.error.mock.calls)).toMatchInlineSnapshot(`
+        "FeatureTogglesError: scope exceeds allowed number of keys
         {
-          "maxKeys": 4,
-          "scopeMap": "{"tenantId":"t1","label":"l1","bla":"b1","naa":"n1","xxx":"x1"}",
-        }
+          scopeMap: '{"tenantId":"t1","label":"l1","bla":"b1","naa":"n1","xxx":"x1"}',
+          maxKeys: 4
+        }"
       `);
     });
 
@@ -288,11 +288,12 @@ describe("feature toggles test", () => {
 
       expect(loggerSpy.warning).toHaveBeenCalledTimes(1);
       expect(loggerSpy.warning).toHaveBeenCalledWith(expect.any(VError));
-      const [loggedErr] = loggerSpy.warning.mock.calls[0];
-      expect(loggedErr).toMatchInlineSnapshot(
-        `[FeatureTogglesError: found invalid fallback values during initialization]`
-      );
-      expect(VError.info(loggedErr)).toMatchSnapshot();
+      expect(outputFromErrorLogger(loggerSpy.warning.mock.calls)).toMatchInlineSnapshot(`
+        "FeatureTogglesError: found invalid fallback values during initialization
+        {
+          validationErrors: '[{"featureKey":"test/feature_b","errorMessage":"value null is not allowed"},{"featureKey":"test/feature_c","errorMessage":"value \\\\"{0}\\\\" has invalid type {1}, must be {2}","errorMessageValues":["1","string","number"]}]'
+        }"
+      `);
       expect(loggerSpy.error).not.toHaveBeenCalled();
     });
 
@@ -1149,6 +1150,32 @@ describe("feature toggles test", () => {
 
       expect(loggerSpy.warning).not.toHaveBeenCalled();
       expect(loggerSpy.error).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("message handling", () => {
+    beforeEach(async () => {
+      await featureToggles.initializeFeatures({ config: mockConfig });
+    });
+
+    it("empty array should be handled fine", async () => {
+      redisWrapperMock.publishMessage(featureToggles.__redisChannel, "[]");
+      expect(loggerSpy.warning).toHaveBeenCalledTimes(0);
+      expect(loggerSpy.error).toHaveBeenCalledTimes(0);
+    });
+
+    it("error in case message is not a serialized array", async () => {
+      redisWrapperMock.publishMessage(featureToggles.__redisChannel, "hello world!");
+      expect(loggerSpy.warning).toHaveBeenCalledTimes(0);
+      expect(loggerSpy.error).toHaveBeenCalledTimes(1);
+      expect(outputFromErrorLogger(loggerSpy.error.mock.calls)).toMatchInlineSnapshot(`
+        "FeatureTogglesError: error during message deserialization
+        { channel: 'feature-channel', message: 'hello world!' }"
+      `);
+    });
+
+    it("all change entries are processed even if one fails", async () => {
+      //
     });
   });
 });

--- a/test/featureToggles.test.js
+++ b/test/featureToggles.test.js
@@ -1211,11 +1211,11 @@ describe("feature toggles test", () => {
       expect(loggerSpy.warning).toHaveBeenCalledTimes(3);
       expect(outputFromErrorLogger(loggerSpy.warning.mock.calls)).toMatchInlineSnapshot(`
         "FeatureTogglesError: received and ignored change entry
-        { changeEntry: '{}' }
+        { channel: 'feature-channel', changeEntry: '{}' }
         FeatureTogglesError: received and ignored change entry
-        { changeEntry: 'null' }
+        { channel: 'feature-channel', changeEntry: 'null' }
         FeatureTogglesError: received and ignored change entry
-        { changeEntry: '"bla"' }"
+        { channel: 'feature-channel', changeEntry: '"bla"' }"
       `);
       expect(loggerSpy.error).toHaveBeenCalledTimes(0);
 

--- a/test/featureToggles.test.js
+++ b/test/featureToggles.test.js
@@ -1211,11 +1211,11 @@ describe("feature toggles test", () => {
       expect(loggerSpy.warning).toHaveBeenCalledTimes(3);
       expect(outputFromErrorLogger(loggerSpy.warning.mock.calls)).toMatchInlineSnapshot(`
         "FeatureTogglesError: received and ignored change entry
-        { channel: 'feature-channel', changeEntry: '{}' }
+        { changeEntry: '{}' }
         FeatureTogglesError: received and ignored change entry
-        { channel: 'feature-channel', changeEntry: 'null' }
+        { changeEntry: 'null' }
         FeatureTogglesError: received and ignored change entry
-        { channel: 'feature-channel', changeEntry: '"bla"' }"
+        { changeEntry: '"bla"' }"
       `);
       expect(loggerSpy.error).toHaveBeenCalledTimes(0);
 


### PR DESCRIPTION
If multiple change entries are pushed on the same message. All entries will now be processed, even if one fails.

- [x] needs a test
