### PR TITLE
Fb/unmanaged values 2

### DIFF
--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -289,7 +289,7 @@ GEM
       concurrent-ruby (~> 1.0)
     unicode-display_width (1.8.0)
     uri (0.13.1)
-    webrick (1.8.1)
+    webrick (1.8.2)
 
 PLATFORMS
   aarch64-linux

--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -83,7 +83,7 @@ And we could change the behavior again with for the more specific user `john` an
 
 - `changeFeatureValue(key, "new value just for john within t1", { user: "john", tenant: "t1" })`
 
-{: .warn}
+{: .warn }
 As we can see in the precedence check order, if we had just set `changeFeatureValue(key, "new value for john", { user: "john" })`,
 then it depends on the order used in the `getFeatureValue` call, whether the `user` scope is evaluated before
 the `tenant` scope.

--- a/docs/plugin/index.md
+++ b/docs/plugin/index.md
@@ -116,7 +116,7 @@ Get all information about the current in-memory state of all toggles.
 <b>Example Request/Response</b>
 
 - Request
-  ```http
+  ```
   GET /rest/feature/state
   Authorization: ...
   ```
@@ -180,7 +180,7 @@ Update the toggle state on Redis, which in turn is published to all server insta
 <b>Example Request/Responses</b>
 
 - Valid Request
-  ```http
+  ```
   POST /rest/feature/redisUpdate
   Authorization: ...
   Content-Type: application/json
@@ -200,7 +200,7 @@ Update the toggle state on Redis, which in turn is published to all server insta
   ```
 
 - Valid Request with [clearSubScopes]({{ site.baseurl }}/usage/#updating-feature-value)
-  ```http
+  ```
   POST /rest/feature/redisUpdate
   Authorization: ...
   Content-Type: application/json
@@ -222,7 +222,7 @@ Update the toggle state on Redis, which in turn is published to all server insta
   ```
 
 - Invalid Request
-  ```http
+  ```
   POST /rest/feature/redisUpdate
   Authorization: ...
   Content-Type: application/json
@@ -256,7 +256,7 @@ Force server to re-sync with Redis, this should never be necessary. It returns t
 <b>Example Request/Response</b>
 
 - Request
-  ```http
+  ```
   POST /rest/feature/redisRead
   Authorization: ...
   ```
@@ -274,7 +274,7 @@ Send an arbitrary command to Redis. [https://redis.io/commands/](https://redis.i
 <b>Example Request/Responses</b>
 
 - Request INFO
-  ```http
+  ```
   POST /rest/feature/redisSendCommand
   Authorization: ...
   Content-Type: application/json
@@ -298,7 +298,7 @@ Send an arbitrary command to Redis. [https://redis.io/commands/](https://redis.i
   ...
   ```
 - Request KEYS
-  ```http
+  ```
   POST /rest/feature/redisSendCommand
   Authorization: ...
   Content-Type: application/json

--- a/docs/plugin/index.md
+++ b/docs/plugin/index.md
@@ -111,7 +111,7 @@ This service endpoint will enable operations teams to understand toggle states. 
 
 ### Read Feature Toggles State
 
-Get all information about the current in-memory state of all toggles.
+Get information about the current in-memory state of all configured toggles.
 
 <b>Example Request/Response</b>
 
@@ -172,6 +172,23 @@ Get all information about the current in-memory state of all toggles.
 
 Similar to the read privilege endpoints, these endpoints are meant to modify toggle state. For practical requests,
 check the [http file](https://github.com/cap-js-community/feature-toggle-library/blob/main/example-cap-server/http/feature-service.http) in our example CAP Server.
+
+### Redis State
+
+Get information about the remote redis state of all maintained toggles, even ones that are not configured. This
+endpoint will show the state within redis. Only toggles that differ from their fallback values are visible there.
+
+<b>Example Request/Response</b>
+
+- Request
+  ```
+  POST /rest/feature/redisRead
+  Authorization: ...
+  ```
+- Response TODO
+  ```
+
+  ```
 
 ### Update Feature Toggle
 
@@ -247,21 +264,6 @@ Update the toggle state on Redis, which in turn is published to all server insta
     }
   }
   ```
-
-### Re-Sync Server with Redis
-
-Force server to re-sync with Redis, this should never be necessary. It returns the same JSON structure as
-`/state`, after re-syncing.
-
-<b>Example Request/Response</b>
-
-- Request
-  ```
-  POST /rest/feature/redisRead
-  Authorization: ...
-  ```
-- Response<br>
-  Same as [Read Feature Toggles State](#read-feature-toggles-state).
 
 ## Service Endpoints for Admin Privilege
 

--- a/docs/plugin/index.md
+++ b/docs/plugin/index.md
@@ -44,7 +44,7 @@ It will usually be sufficient to set the `serviceAccessRoles` configuration, whi
 endpoints, but not the admin endpoints. If more discriminating access control is required, the `readAccessRoles` and
 `writeAccessRoles` can be set separately. For debugging purposes, you can also set the `adminAccessRoles`.
 
-{: .warn}
+{: .warn }
 As the name suggests, the `adminAccessRoles` should be considered sensitive. It allows direct root access to the
 underlying redis.
 
@@ -97,7 +97,7 @@ automatically detect it and configure it as follows:
   fallbackValue: false
 ```
 
-{: .info}
+{: .info }
 This automatic configuration can be _overwritten_, by using a configuration file and adding a dedicated configuration
 with the same key `/fts/my-feature`.
 
@@ -109,7 +109,7 @@ for the related requests. For an example check out the [Example CAP Server](http
 This service endpoint will enable operations teams to understand toggle states. For practical requests, check the
 [http file](https://github.com/cap-js-community/feature-toggle-library/blob/main/example-cap-server/http/feature-service.http) in our example CAP Server.
 
-### Read Feature Toggles State
+### Read Server State
 
 Get information about the current in-memory state of all configured toggles.
 
@@ -168,12 +168,7 @@ Get information about the current in-memory state of all configured toggles.
   }
   ```
 
-## Service Endpoints for Write Privilege
-
-Similar to the read privilege endpoints, these endpoints are meant to modify toggle state. For practical requests,
-check the [http file](https://github.com/cap-js-community/feature-toggle-library/blob/main/example-cap-server/http/feature-service.http) in our example CAP Server.
-
-### Redis State
+### Read Redis State
 
 Get information about the remote redis state of all maintained toggles, even ones that are not configured. This
 endpoint will show the state within redis. Only toggles that differ from their fallback values are visible there.
@@ -185,10 +180,58 @@ endpoint will show the state within redis. Only toggles that differ from their f
   POST /rest/feature/redisRead
   Authorization: ...
   ```
-- Response TODO
+- Response
+  ```
+  HTTP/1.1 200 OK
+  ...
+  ```
+  ```json
+  {
+    "/check/priority": {
+      "fallbackValue": 0,
+      "rootValue": 1,
+      "scopedValues": {
+        "tenant::people": 10,
+        "user::alice@wonderland.com": 100
+      },
+      "config": {
+        "SOURCE": "FILE",
+        "TYPE": "number",
+        "VALIDATIONS": [
+          {
+            "scopes": ["user", "tenant"]
+          },
+          {
+            "regex": "^\\d+$"
+          },
+          {
+            "module": "$CONFIG_DIR/validators",
+            "call": "validateTenantScope"
+          }
+        ]
+      }
+    },
+    "/legacy-key": {
+      "rootValue": 10,
+      "scopedValues": {
+        "tenant::a": 100,
+        "tenant::b": 1000
+      },
+      "config": {
+        "SOURCE": "NONE"
+      }
+    }
+  }
   ```
 
-  ```
+{: .info }
+Note that reading the redis state directly can reveal legacy key values that used to be configured and maintained but
+are no longer in the configuration. These values can be cleaned up by using the [redisUpdate](#update-feature-toggle) endpoint with the `remoteOnly` option.
+
+## Service Endpoints for Write Privilege
+
+Similar to the read privilege endpoints, these endpoints are meant to modify toggle state. For practical requests,
+check the [http file](https://github.com/cap-js-community/feature-toggle-library/blob/main/example-cap-server/http/feature-service.http) in our example CAP Server.
 
 ### Update Feature Toggle
 

--- a/docs/plugin/index.md
+++ b/docs/plugin/index.md
@@ -178,8 +178,15 @@ values, so they will use their fallback values.
 
 ### Read Redis State
 
-Get information about the remote redis state of all maintained toggles, even ones that are not configured. This
-endpoint will show the state within redis. Only toggles that differ from their fallback values are visible there.
+Get information about the remote redis state of all toggles with maintained values, even ones that are not configured.
+This endpoint will show the state within redis. Only toggles with maintained values will be shown here. In the example,
+we can see `/check/priority` with the maintained values. We can also see a `/legacy-key` toggle, which has maintained
+values that are not associated with a configuration `{ "SOURCE": "NONE" }`.
+
+{: .info }
+Note that reading the redis state can reveal legacy key values that used to be configured and maintained but are no
+longer in the configuration. These values can be cleaned up by using the [redisUpdate](#update-feature-toggle) endpoint
+with the `remoteOnly` option.
 
 <b>Example Request/Response</b>
 
@@ -231,10 +238,6 @@ endpoint will show the state within redis. Only toggles that differ from their f
     }
   }
   ```
-
-{: .info }
-Note that reading the redis state directly can reveal legacy key values that used to be configured and maintained but
-are no longer in the configuration. These values can be cleaned up by using the [redisUpdate](#update-feature-toggle) endpoint with the `remoteOnly` option.
 
 ## Service Endpoints for Write Privilege
 

--- a/docs/plugin/index.md
+++ b/docs/plugin/index.md
@@ -111,7 +111,10 @@ This service endpoint will enable operations teams to understand toggle states. 
 
 ### Read Server State
 
-Get information about the current in-memory state of all configured toggles.
+Get information about the current in-memory state of all configured toggles. The response will give you transparency
+about maintained values and the underlying configuration of the toggles. In the following example, the
+`/check/priority` toggle has a maintained root value, and two scoped values. All other toggles have no maintained
+values, so they will use their fallback values.
 
 <b>Example Request/Response</b>
 
@@ -129,6 +132,11 @@ Get information about the current in-memory state of all configured toggles.
   {
     "/check/priority": {
       "fallbackValue": 0,
+      "rootValue": 1,
+      "scopedValues": {
+        "tenant::people": 10,
+        "user::alice@wonderland.com": 100
+      },
       "config": {
         "SOURCE": "FILE",
         "TYPE": "number",

--- a/docs/plugin/index.md
+++ b/docs/plugin/index.md
@@ -281,6 +281,29 @@ Update the toggle state on Redis, which in turn is published to all server insta
   ...
   ```
 
+- Valid Request with [remoteOnly]({{ site.baseurl }}/usage/#updating-feature-value)
+  ```
+  POST /rest/feature/redisUpdate
+  Authorization: ...
+  Content-Type: application/json
+  ```
+  ```json
+  {
+    "key": "/legacy-key",
+    "value": null,
+    "options": {
+      "clearSubScopes": true,
+      "remoteOnly": true
+    }
+  }
+  ```
+- Response
+
+  ```
+  HTTP/1.1 204 No Content
+  ...
+  ```
+
 - Invalid Request
   ```
   POST /rest/feature/redisUpdate

--- a/docs/plugin/index.md
+++ b/docs/plugin/index.md
@@ -188,7 +188,7 @@ Note that reading the redis state can reveal legacy key values that used to be c
 longer in the configuration. These values can be cleaned up by using the [redisUpdate](#update-feature-toggle) endpoint
 with the `remoteOnly` option.
 
-<b>Example Request/Response</b>
+<b>Example Request/Responses</b>
 
 - Request
   ```
@@ -246,7 +246,7 @@ check the [http file](https://github.com/cap-js-community/feature-toggle-library
 
 ### Update Feature Toggle
 
-Update the toggle state on Redis, which in turn is published to all server instances.
+Maintain a particular toggle value on Redis, which is automatically propagated to all server instances.
 
 <b>Example Request/Responses</b>
 

--- a/docs/usage/index.md
+++ b/docs/usage/index.md
@@ -305,7 +305,7 @@ value.
 _Option: clearSubScopes_
 
 Since setting values for scope-combinations happens additively, it can become hard to keep track of which combinations
-have dedicated values attached to them. If you want to set a value _and_ make sure that there isn't a more specific
+have maintained values attached to them. If you want to set a value _and_ make sure that there isn't a more specific
 scope-combination, which overrides that value, then you can use the option `{ clearSubScopes: true }` as a third
 argument. For example
 
@@ -319,15 +319,15 @@ will set the root-scope value to `"error"` and remove all sub-scopes. See
 _Option: remoteOnly_
 
 When you find toggle values in Redis that are not configured, marked with `{ "SOURCE": "NONE" }`, it usually makes
-sense to remove them. In this situation we want to change _just Redis_, but bypass the local server state update and
-the usual validation, change handlers, and server instance change propagation. To achieve this, you can use the
+sense to remove them. In this situation, we want to change _just Redis_ and bypass the local server state update, the
+usual validation, change handlers, and server instance change propagation. To achieve this, you can use the
 `{ remoteOnly: true }` option. For example
 
 ```javascript
 await toggles.changeFeatureValue("/legacy-key", null, {}, { clearSubScopes: true, remoteOnly: true });
 ```
 
-will remove all Redis toggle values associated with the `/legacy-key` key.
+will remove all maintained values associated with the `/legacy-key` key in Redis.
 
 {: .info }
 Changes with the `{ remoteOnly: true }` option will be blocked for _configured_ toggles. This happens to avoid

--- a/docs/usage/index.md
+++ b/docs/usage/index.md
@@ -321,13 +321,18 @@ _Option: remoteOnly_
 When you find toggle values in Redis that are not configured, marked with `{ "SOURCE": "NONE" }`, it usually makes
 sense to remove them. In this situation we want to change _just Redis_, but bypass the local server state update and
 the usual validation, change handlers, and server instance change propagation. To achieve this, you can use the
-`remoteOnly` option. For example
+`{ remoteOnly: true }` option. For example
 
 ```javascript
 await toggles.changeFeatureValue("/legacy-key", null, {}, { clearSubScopes: true, remoteOnly: true });
 ```
 
 will remove all Redis toggle values associated with the `/legacy-key` key.
+
+{: .info }
+Changes with the `{ remoteOnly: true }` option will be blocked for _configured_ toggles. In order to avoid situations
+where the remote state of these toggles is accidentally changed in a way that bypasses validations and server state
+updates.
 
 ### Resetting Feature Value
 

--- a/docs/usage/index.md
+++ b/docs/usage/index.md
@@ -330,9 +330,9 @@ await toggles.changeFeatureValue("/legacy-key", null, {}, { clearSubScopes: true
 will remove all Redis toggle values associated with the `/legacy-key` key.
 
 {: .info }
-Changes with the `{ remoteOnly: true }` option will be blocked for _configured_ toggles. In order to avoid situations
-where the remote state of these toggles is accidentally changed in a way that bypasses validations and server state
-updates.
+Changes with the `{ remoteOnly: true }` option will be blocked for _configured_ toggles. This happens to avoid
+situations where the remote state of these toggles is accidentally changed in a way that bypasses validations and
+server state updates.
 
 ### Resetting Feature Value
 

--- a/docs/usage/index.md
+++ b/docs/usage/index.md
@@ -302,6 +302,8 @@ processing delay until the change is picked up by all subscribers.
 Setting a feature value to `null` will delete the associated remote state and effectively reset it to its fallback
 value.
 
+_Option: clearSubScopes_
+
 Since setting values for scope-combinations happens additively, it can become hard to keep track of which combinations
 have dedicated values attached to them. If you want to set a value _and_ make sure that there isn't a more specific
 scope-combination, which overrides that value, then you can use the option `{ clearSubScopes: true }` as a third
@@ -313,6 +315,19 @@ await toggles.changeFeatureValue("/srv/util/logger/logLevel", "error", {}, { cle
 
 will set the root-scope value to `"error"` and remove all sub-scopes. See
 [scoping]({{ site.baseurl }}/concepts/#scoping) for context.
+
+_Option: remoteOnly_
+
+When you find toggle values in Redis that are not configured, marked with `{ "SOURCE": "NONE" }`, it usually makes
+sense to remove them. In this situation we want to change _just Redis_, but bypass the local server state update and
+the usual validation, change handlers, and server instance change propagation. To achieve this, you can use the
+`remoteOnly` option. For example
+
+```javascript
+await toggles.changeFeatureValue("/legacy-key", null, {}, { clearSubScopes: true, remoteOnly: true });
+```
+
+will remove all Redis toggle values associated with the `/legacy-key` key.
 
 ### Resetting Feature Value
 

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -25,8 +25,8 @@ const ACCESS = Object.freeze({
   ADMIN: "ADMIN",
 });
 const SERVICE_ENDPOINTS = Object.freeze({
-  [ACCESS.READ]: [`${SERVICE_NAME}.state`],
-  [ACCESS.WRITE]: [`${SERVICE_NAME}.redisRead`, `${SERVICE_NAME}.redisUpdate`],
+  [ACCESS.READ]: [`${SERVICE_NAME}.state`, `${SERVICE_NAME}.redisRead`],
+  [ACCESS.WRITE]: [`${SERVICE_NAME}.redisUpdate`],
   [ACCESS.ADMIN]: [`${SERVICE_NAME}.redisSendCommand`],
 });
 

--- a/test/__mocks__/redisWrapper.js
+++ b/test/__mocks__/redisWrapper.js
@@ -20,8 +20,13 @@ const type = jest.fn(async () => "hash");
 const watchedHashGetSetObject = jest.fn(async (key, field, newValueCallback) => {
   mockRedisState.values = mockRedisState.values ? mockRedisState.values : {};
   mockRedisState.values[key] = mockRedisState.values[key] ? mockRedisState.values[key] : {};
-  mockRedisState.values[key][field] = await newValueCallback(mockRedisState.values[key][field]);
-  return mockRedisState.values[key][field];
+  const newValue = await newValueCallback(mockRedisState.values[key][field]);
+  if (newValue === null) {
+    Reflect.deleteProperty(mockRedisState.values[key], field);
+  } else {
+    mockRedisState.values[key][field] = newValue;
+  }
+  return newValue;
 });
 
 const registerMessageHandler = jest.fn((channel, handler) => {

--- a/test/__mocks__/redisWrapper.js
+++ b/test/__mocks__/redisWrapper.js
@@ -56,6 +56,7 @@ module.exports = {
   publishMessage,
   type,
   getObject,
+  hashGetAllObjects: jest.fn(),
   watchedHashGetSetObject,
   subscribe: jest.fn(),
   getIntegrationMode: jest.fn(() => REDIS_INTEGRATION_MODE.CF_REDIS),

--- a/test/__mocks__/redisWrapper.js
+++ b/test/__mocks__/redisWrapper.js
@@ -10,6 +10,11 @@ const getObject = jest.fn(async (key) => {
   return mockRedisState.values[key];
 });
 
+const hashGetAllObjects = jest.fn(async () => {
+  mockRedisState.values = mockRedisState.values ? mockRedisState.values : {};
+  return mockRedisState.values[redisKey];
+});
+
 const type = jest.fn(async () => "hash");
 
 const watchedHashGetSetObject = jest.fn(async (key, field, newValueCallback) => {
@@ -56,7 +61,7 @@ module.exports = {
   publishMessage,
   type,
   getObject,
-  hashGetAllObjects: jest.fn(),
+  hashGetAllObjects,
   watchedHashGetSetObject,
   subscribe: jest.fn(),
   getIntegrationMode: jest.fn(() => REDIS_INTEGRATION_MODE.CF_REDIS),

--- a/test/__snapshots__/featureToggles.test.js.snap
+++ b/test/__snapshots__/featureToggles.test.js.snap
@@ -123,6 +123,31 @@ exports[`feature toggles test basic apis getFeaturesInfos 1`] = `
 }
 `;
 
+exports[`feature toggles test basic apis getRemoteFeaturesInfos 1`] = `
+{
+  "legacy-key": {
+    "config": {
+      "SOURCE": "NONE",
+    },
+    "rootValue": "legacy-root",
+    "scopedValues": {
+      "tenant::a": "legacy-scoped-value",
+    },
+  },
+  "test/feature_b": {
+    "config": {
+      "SOURCE": "RUNTIME",
+      "TYPE": "number",
+    },
+    "fallbackValue": 1,
+    "rootValue": 1,
+    "scopedValues": {
+      "tenant::a": 10,
+    },
+  },
+}
+`;
+
 exports[`feature toggles test basic apis initializeFeatureToggles 1`] = `
 {
   "test/feature_a": {

--- a/test/featureToggles.test.js
+++ b/test/featureToggles.test.js
@@ -550,7 +550,7 @@ describe("feature toggles test", () => {
           "fallbackValue": "best",
         }
       `);
-      expect(toggles.getFeatureInfo("unmanaged-key")).toBe(null);
+      expect(toggles.getFeatureInfo(legacyKey)).toBe(null);
     });
 
     test("getFeaturesInfos", async () => {

--- a/test/featureToggles.test.js
+++ b/test/featureToggles.test.js
@@ -698,11 +698,14 @@ describe("feature toggles test", () => {
 
     test("changeFeatureValue with option clearSubScopes", async () => {
       await toggles.initializeFeatures({ config: mockConfig });
-      expect(await toggles.changeFeatureValue(FEATURE.B, 10)).toBeUndefined();
-      expect(await toggles.changeFeatureValue(FEATURE.B, 100, { tenant: "a" })).toBeUndefined();
-      expect(await toggles.changeFeatureValue(FEATURE.B, 1000, { tenant: "b" })).toBeUndefined();
-      redisWrapperMock.publishMessage.mockClear();
       redisWrapperMock.watchedHashGetSetObject.mockClear();
+      await redisWrapperMock._setValues({
+        [FEATURE.B]: {
+          [SCOPE_ROOT_KEY]: 10,
+          [FeatureToggles.getScopeKey({ tenant: "a" })]: 100,
+          [FeatureToggles.getScopeKey({ tenant: "b" })]: 1000,
+        },
+      });
 
       expect(await toggles.changeFeatureValue(FEATURE.B, 11, {}, { clearSubScopes: true })).toBeUndefined();
       expect(toggles.getFeatureInfo(FEATURE.B)).toMatchInlineSnapshot(`

--- a/test/featureToggles.test.js
+++ b/test/featureToggles.test.js
@@ -549,11 +549,30 @@ describe("feature toggles test", () => {
           "fallbackValue": "best",
         }
       `);
+      expect(toggles.getFeatureInfo("unmanaged-key")).toBe(null);
     });
 
     test("getFeaturesInfos", async () => {
       await toggles.initializeFeatures({ config: mockConfig });
+
       expect(toggles.getFeaturesInfos()).toMatchSnapshot();
+      expect(loggerSpy.warning).not.toHaveBeenCalled();
+      expect(loggerSpy.error).not.toHaveBeenCalled();
+    });
+
+    test("getRemoteFeaturesInfos", async () => {
+      await toggles.initializeFeatures({ config: mockConfig });
+      redisWrapperMock.hashGetAllObjects.mockImplementationOnce(() => ({
+        [FEATURE.B]: { [SCOPE_ROOT_KEY]: 1, [FeatureToggles.getScopeKey({ tenant: "a" })]: 10 },
+        "legacy-key": {
+          [SCOPE_ROOT_KEY]: "legacy-root",
+          [FeatureToggles.getScopeKey({ tenant: "a" })]: "legacy-scoped-value",
+        },
+      }));
+
+      expect(await toggles.getRemoteFeaturesInfos()).toMatchSnapshot();
+      expect(loggerSpy.warning).not.toHaveBeenCalled();
+      expect(loggerSpy.error).not.toHaveBeenCalled();
     });
 
     test("getFeatureValue", async () => {

--- a/test/featureToggles.test.js
+++ b/test/featureToggles.test.js
@@ -753,16 +753,10 @@ describe("feature toggles test", () => {
       });
 
       expect(
-        await toggles.changeFeatureValue(legacyKey, 21, {}, { clearSubScopes: true, remoteOnly: true })
+        await toggles.changeFeatureValue(legacyKey, null, {}, { clearSubScopes: true, remoteOnly: true })
       ).toBeUndefined();
       expect(await toggles.getRemoteFeaturesInfos()).toMatchInlineSnapshot(`
         {
-          "legacy-key": {
-            "config": {
-              "SOURCE": "NONE",
-            },
-            "rootValue": 21,
-          },
           "test/feature_b": {
             "config": {
               "SOURCE": "RUNTIME",


### PR DESCRIPTION
Follow up for #71 

- [x] Tests for `getRemoteFeaturesInfos` and `changeFeatureValue` with `remoteOnly` option
- [x] BREAKING change `redisRead` is now a read-privilege endpoint
- [x] Docs: document `redisRead` `redisUpdate` changes
- [x] Docs: document `changeFeatureValue` new option
- [x] Docs: update dependency webrick
