### PR TITLE
go back to exporting classes

### DIFF
--- a/src/feature-toggles.js
+++ b/src/feature-toggles.js
@@ -19,7 +19,7 @@ const VError = require("verror");
 const yaml = require("yaml");
 const redis = require("./redis-wrapper");
 const { REDIS_INTEGRATION_MODE } = redis;
-const { cfEnv } = require("./shared/cf-env");
+const { CfEnv } = require("./shared/cf-env");
 const { Logger } = require("./shared/logger");
 const { HandlerCollection } = require("./shared/handler-collection");
 const { LimitedLazyCache } = require("./shared/cache");
@@ -112,6 +112,7 @@ const SCOPE_PREFERENCE_ORDER_MASKS = [
   ],
 ];
 
+const cfEnv = CfEnv.getInstance();
 const readFileAsync = util.promisify(readFile);
 let logger = new Logger(COMPONENT_NAME);
 
@@ -1663,7 +1664,6 @@ module.exports = {
   DEFAULT_REDIS_KEY,
   SCOPE_ROOT_KEY,
   FeatureToggles,
-  toggles: FeatureToggles.getInstance(),
 
   _: {
     CONFIG_KEY,

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 "use strict";
 
-const { toggles } = require("./feature-toggles");
+const { FeatureToggles } = require("./feature-toggles");
 
+const toggles = FeatureToggles.getInstance();
 module.exports = toggles;

--- a/src/redis-wrapper.js
+++ b/src/redis-wrapper.js
@@ -8,7 +8,7 @@
 
 const redis = require("redis");
 const VError = require("verror");
-const { cfEnv } = require("./shared/cf-env");
+const { CfEnv } = require("./shared/cf-env");
 const { Logger } = require("./shared/logger");
 const { HandlerCollection } = require("./shared/handler-collection");
 const { Semaphore } = require("./shared/semaphore");
@@ -25,6 +25,7 @@ const INTEGRATION_MODE = Object.freeze({
 });
 const CF_REDIS_SERVICE_LABEL = "redis-cache";
 
+const cfEnv = CfEnv.getInstance();
 const logger = new Logger(COMPONENT_NAME);
 
 const MODE = Object.freeze({

--- a/src/shared/cf-env.js
+++ b/src/shared/cf-env.js
@@ -64,5 +64,5 @@ class CfEnv {
 
 module.exports = {
   ENV,
-  cfEnv: CfEnv.getInstance(),
+  CfEnv,
 };

--- a/src/shared/logger.js
+++ b/src/shared/logger.js
@@ -2,7 +2,7 @@
 const util = require("util");
 const VError = require("verror");
 
-const { cfEnv } = require("./cf-env");
+const { CfEnv } = require("./cf-env");
 const { tryRequire } = require("./static");
 const cds = tryRequire("@sap/cds");
 
@@ -75,6 +75,7 @@ const FORMAT = Object.freeze({
 const MILLIS_IN_NANOS_NUMBER = 1000000;
 const MILLIS_IN_NANOS_BIGINT = BigInt(MILLIS_IN_NANOS_NUMBER);
 
+const cfEnv = CfEnv.getInstance();
 const cfApp = cfEnv.cfApp;
 const cfAppData = cfEnv.isOnCf
   ? {

--- a/test/__mocks__/cf-env.js
+++ b/test/__mocks__/cf-env.js
@@ -10,4 +10,8 @@ const cfEnv = {
 };
 cfEnv._reset();
 
-module.exports = { cfEnv };
+const CfEnv = {
+  getInstance: () => cfEnv,
+};
+
+module.exports = { CfEnv };

--- a/test/__mocks__/cf-env.js
+++ b/test/__mocks__/cf-env.js
@@ -1,17 +1,21 @@
 "use strict";
 
-const cfEnv = {
+class CfEnv {
   _reset() {
     this.isOnCf = false;
     this.cfApp = {};
     this.cfServices = {};
     this.cfServiceCredentialsForLabel = jest.fn().mockReturnValue({});
-  },
-};
-cfEnv._reset();
-
-const CfEnv = {
-  getInstance: () => cfEnv,
-};
+  }
+  constructor() {
+    this._reset();
+  }
+  static getInstance() {
+    if (!CfEnv.__instance) {
+      CfEnv.__instance = new CfEnv();
+    }
+    return CfEnv.__instance;
+  }
+}
 
 module.exports = { CfEnv };

--- a/test/feature-toggles.test.js
+++ b/test/feature-toggles.test.js
@@ -24,7 +24,8 @@ jest.mock("fs", () => ({
   access: jest.fn((cb) => cb()),
 }));
 
-const { cfEnv: envMock } = require("../src/shared/cf-env");
+const { CfEnv } = require("../src/shared/cf-env");
+const envMock = CfEnv.getInstance();
 jest.mock("../src/shared/cf-env", () => require("./__mocks__/cf-env"));
 
 const redisWrapperMock = require("../src/redis-wrapper");

--- a/test/redis-wrapper.test.js
+++ b/test/redis-wrapper.test.js
@@ -1,6 +1,7 @@
 "use strict";
 
-const { cfEnv: envMock } = require("../src/shared/cf-env");
+const { CfEnv } = require("../src/shared/cf-env");
+const envMock = CfEnv.getInstance();
 jest.mock("../src/shared/cf-env", () => require("./__mocks__/cf-env"));
 
 const mockMessageHandler = jest.fn();

--- a/test/shared/cf-env.test.js
+++ b/test/shared/cf-env.test.js
@@ -108,7 +108,8 @@ describe("cfenv test", () => {
     backupCfServicesEnv = process.env.VCAP_SERVICES;
     process.env.VCAP_APPLICATION = JSON.stringify(mockCfAppEnv);
     process.env.VCAP_SERVICES = JSON.stringify(mockCfServicesEnv);
-    ({ cfEnv } = require("../../src/shared/cf-env"));
+    const { CfEnv } = require("../../src/shared/cf-env");
+    cfEnv = CfEnv.getInstance();
   });
 
   afterAll(() => {

--- a/test/shared/logger.test.js
+++ b/test/shared/logger.test.js
@@ -8,7 +8,8 @@ const { ENV, LEVEL, FORMAT, Logger } = require("../../src/shared/logger");
 const redisWrapperMock = require("../../src/redis-wrapper");
 jest.mock("../../src/redis-wrapper", () => require("../__mocks__/redis-wrapper"));
 
-const { cfEnv: envMock } = require("../../src/shared/cf-env");
+const { CfEnv } = require("../../src/shared/cf-env");
+const envMock = CfEnv.getInstance();
 jest.mock("../../src/shared/cf-env", () => require("../__mocks__/cf-env"));
 
 const { FEATURE, mockConfig, redisKey, redisChannel, refreshMessage } = require("../__common__/mockdata");


### PR DESCRIPTION
I want the requires to run a minimal amount of code, and calling getInstance() to create an instance is not strictly needed and can even be destructive if the instance reacts to the environment. In this case, the timing of the require call becomes relevant and that's bad.
