### PR TITLE
chore: srv.operations does not need namespace

### DIFF
--- a/example-cap-server/srv/service/check-service.js
+++ b/example-cap-server/srv/service/check-service.js
@@ -29,6 +29,6 @@ const priorityHandler = async (context) => {
 };
 
 module.exports = async (srv) => {
-  const { priority } = srv.operations("CheckService");
+  const { priority } = srv.operations;
   srv.on(priority, priorityHandler);
 };

--- a/src/service/feature-service.js
+++ b/src/service/feature-service.js
@@ -126,7 +126,7 @@ const redisSendCommandHandler = async (context) => {
 };
 
 module.exports = async (srv) => {
-  const { state, redisRead, redisUpdate, redisSendCommand } = srv.operations("FeatureService");
+  const { state, redisRead, redisUpdate, redisSendCommand } = srv.operations;
   srv.on(state, stateHandler);
   srv.on(redisRead, redisReadHandler);
   srv.on(redisUpdate, redisUpdateHandler);


### PR DESCRIPTION
srv.operations is a function and object at the same time. The object variant already includes all the operations of the service. The function call loops over the model and returns effectively the same object.

In a future major release, we plan to remove the function part as it's not needed.