### PR TITLE
Fb/multifile

### DIFF
--- a/src/feature-toggles.js
+++ b/src/feature-toggles.js
@@ -294,10 +294,11 @@ class FeatureToggles {
    */
   _processConfig({ configRuntime, configFromFilesEntries, configAuto } = {}) {
     const configRuntimeCount = this._processConfigSource(CONFIG_SOURCE.RUNTIME, configRuntime);
-    const configFromFileCount = configFromFilesEntries.reduce((count, [configFilepath, configFromFile]) => {
-      count += this._processConfigSource(CONFIG_SOURCE.FILE, configFromFile, configFilepath);
-      return count;
-    }, 0);
+    const configFromFileCount = configFromFilesEntries.reduce(
+      (count, [configFilepath, configFromFile]) =>
+        count + this._processConfigSource(CONFIG_SOURCE.FILE, configFromFile, configFilepath),
+      0
+    );
     const configAutoCount = this._processConfigSource(CONFIG_SOURCE.AUTO, configAuto);
 
     this.__isConfigProcessed = true;

--- a/src/feature-toggles.js
+++ b/src/feature-toggles.js
@@ -229,7 +229,17 @@ class FeatureToggles {
     const entries = Object.entries(configFromSource);
     for (const [featureKey, value] of entries) {
       if (this.__config[featureKey]) {
-        continue;
+        throw new VError(
+          {
+            name: VERROR_CLUSTER_NAME,
+            info: {
+              featureKey,
+              source,
+              ...(configFilepath && { configFilepath }),
+            },
+          },
+          "feature is configured twice"
+        );
       }
       count++;
 

--- a/src/feature-toggles.js
+++ b/src/feature-toggles.js
@@ -58,6 +58,7 @@ const CONFIG_KEY = Object.freeze({
   TYPE: "TYPE",
   ACTIVE: "ACTIVE",
   SOURCE: "SOURCE",
+  SOURCE_FILEPATH: "SOURCE_FILEPATH",
   APP_URL: "APP_URL",
   APP_URL_ACTIVE: "APP_URL_ACTIVE",
   VALIDATIONS: "VALIDATIONS",
@@ -240,13 +241,19 @@ class FeatureToggles {
           }
           case CONFIG_MERGE_CONFLICT.THROW: // eslint-disable-current-line no-fallthrough
           default: {
+            const sourceExisting = this.__config[featureKey][CONFIG_KEY.SOURCE];
+            const sourceConflicting = source;
+            const sourceFilepathExisting = this.__config[featureKey][CONFIG_KEY.SOURCE_FILEPATH];
+            const sourceFilepathConflicting = configFilepath;
             throw new VError(
               {
                 name: VERROR_CLUSTER_NAME,
                 info: {
                   featureKey,
-                  source,
-                  ...(configFilepath && { configFilepath }),
+                  sourceExisting,
+                  sourceConflicting,
+                  ...(sourceFilepathExisting && { sourceFilepathExisting }),
+                  ...(sourceFilepathConflicting && { sourceFilepathConflicting }),
                 },
               },
               "feature is configured twice"
@@ -276,6 +283,10 @@ class FeatureToggles {
       this.__config[featureKey] = {};
 
       this.__config[featureKey][CONFIG_KEY.SOURCE] = source;
+
+      if (configFilepath) {
+        this.__config[featureKey][CONFIG_KEY.SOURCE_FILEPATH] = configFilepath;
+      }
 
       if (type) {
         this.__config[featureKey][CONFIG_KEY.TYPE] = type;

--- a/src/feature-toggles.js
+++ b/src/feature-toggles.js
@@ -282,10 +282,13 @@ class FeatureToggles {
   /**
    * Populate this.__config.
    */
-  _processConfig({ configRuntime, configFromFilesMap, configAuto } = {}) {
-    const configRuntimeCount = this._processConfigSource(CONFIG_SOURCE.RUNTIME, configRuntime, configFilepath);
-    const configFromFileCount = this._processConfigSource(CONFIG_SOURCE.FILE, configFromFile, configFilepath);
-    const configAutoCount = this._processConfigSource(CONFIG_SOURCE.AUTO, configAuto, configFilepath);
+  _processConfig({ configRuntime, configFromFilesWithPath, configAuto } = {}) {
+    const configRuntimeCount = this._processConfigSource(CONFIG_SOURCE.RUNTIME, configRuntime);
+    const configFromFileCount = configFromFilesWithPath.reduce((count, { configFilepath, configFromFile }) => {
+      count += this._processConfigSource(CONFIG_SOURCE.FILE, configFromFile, configFilepath);
+      return count;
+    }, 0);
+    const configAutoCount = this._processConfigSource(CONFIG_SOURCE.AUTO, configAuto);
 
     this.__isConfigProcessed = true;
     return {
@@ -793,7 +796,7 @@ class FeatureToggles {
 
     let toggleCounts;
     try {
-      toggleCounts = this._processConfig({ configRuntime, configFromFilesWithPath, configAuto, configFilepath });
+      toggleCounts = this._processConfig({ configRuntime, configFromFilesWithPath, configAuto });
     } catch (err) {
       throw new VError(
         {
@@ -801,7 +804,7 @@ class FeatureToggles {
           cause: err,
           info: {
             ...(configRuntime && { configRuntime: JSON.stringify(configRuntime) }),
-            ...(configFromFilesMap && { configFromFilesMap: JSON.stringify(configFromFilesMap) }),
+            ...(configFromFilesWithPath && { configFromFilesMap: JSON.stringify(configFromFilesWithPath) }),
             ...(configAuto && { configAuto: JSON.stringify(configAuto) }),
           },
         },

--- a/src/feature-toggles.js
+++ b/src/feature-toggles.js
@@ -225,7 +225,7 @@ class FeatureToggles {
     }
   }
 
-  _processConfigSource(source, mergeConflictBehavior, configFromSource, configFilepath) {
+  _processConfigSource(source, mergeConflictBehavior, configFromSource, sourceFilepath) {
     let count = 0;
     if (!isObject(configFromSource)) {
       return count;
@@ -244,7 +244,7 @@ class FeatureToggles {
             const sourceExisting = this.__config[featureKey][CONFIG_KEY.SOURCE];
             const sourceConflicting = source;
             const sourceFilepathExisting = this.__config[featureKey][CONFIG_KEY.SOURCE_FILEPATH];
-            const sourceFilepathConflicting = configFilepath;
+            const sourceFilepathConflicting = sourceFilepath;
             throw new VError(
               {
                 name: VERROR_CLUSTER_NAME,
@@ -270,6 +270,7 @@ class FeatureToggles {
             info: {
               featureKey,
               source,
+              ...(sourceFilepath && { sourceFilepath }),
             },
           },
           "feature configuration is not an object"
@@ -284,8 +285,8 @@ class FeatureToggles {
 
       this.__config[featureKey][CONFIG_KEY.SOURCE] = source;
 
-      if (configFilepath) {
-        this.__config[featureKey][CONFIG_KEY.SOURCE_FILEPATH] = configFilepath;
+      if (sourceFilepath) {
+        this.__config[featureKey][CONFIG_KEY.SOURCE_FILEPATH] = sourceFilepath;
       }
 
       if (type) {
@@ -306,7 +307,7 @@ class FeatureToggles {
 
       if (validations) {
         this.__config[featureKey][CONFIG_KEY.VALIDATIONS] = validations;
-        this._processValidations(featureKey, validations, configFilepath);
+        this._processValidations(featureKey, validations, sourceFilepath);
       }
     }
 
@@ -782,7 +783,7 @@ class FeatureToggles {
         name: VERROR_CLUSTER_NAME,
         info: { configFilepath },
       },
-      "configFilepath with unsupported extension, allowed extensions are .yaml and .json"
+      "config filepath with unsupported extension, allowed extensions are .yaml and .json"
     );
   }
 
@@ -850,11 +851,6 @@ class FeatureToggles {
         {
           name: VERROR_CLUSTER_NAME,
           cause: err,
-          info: {
-            ...(configRuntime && { configRuntime: JSON.stringify(configRuntime) }),
-            ...(configFromFilesEntries && { configFromFilesEntries: JSON.stringify(configFromFilesEntries) }),
-            ...(configAuto && { configAuto: JSON.stringify(configAuto) }),
-          },
         },
         "initialization aborted, could not process configuration"
       );

--- a/src/feature-toggles.js
+++ b/src/feature-toggles.js
@@ -808,7 +808,7 @@ class FeatureToggles {
           cause: err,
           info: {
             ...(configRuntime && { configRuntime: JSON.stringify(configRuntime) }),
-            ...(configFromFilesEntries && { configFromFilesMap: JSON.stringify(configFromFilesEntries) }),
+            ...(configFromFilesEntries && { configFromFilesEntries: JSON.stringify(configFromFilesEntries) }),
             ...(configAuto && { configAuto: JSON.stringify(configAuto) }),
           },
         },

--- a/src/feature-toggles.js
+++ b/src/feature-toggles.js
@@ -51,7 +51,8 @@ const CONFIG_SOURCE = Object.freeze({
 
 const CONFIG_MERGE_CONFLICT = Object.freeze({
   THROW: "THROW",
-  KEEP_EXISTING: "KEEP_EXISTING",
+  PRESERVE: "PRESERVE",
+  OVERRIDE: "OVERRIDE",
 });
 
 const CONFIG_KEY = Object.freeze({
@@ -236,7 +237,7 @@ class FeatureToggles {
     for (const [featureKey, value] of entries) {
       if (this.__config[featureKey]) {
         switch (mergeConflictBehavior) {
-          case CONFIG_MERGE_CONFLICT.KEEP_EXISTING: {
+          case CONFIG_MERGE_CONFLICT.PRESERVE: {
             continue;
           }
           case CONFIG_MERGE_CONFLICT.THROW: // eslint-disable-current-line no-fallthrough
@@ -329,11 +330,7 @@ class FeatureToggles {
         this._processConfigSource(CONFIG_SOURCE.FILE, CONFIG_MERGE_CONFLICT.THROW, configFromFile, configFilepath),
       0
     );
-    const configAutoCount = this._processConfigSource(
-      CONFIG_SOURCE.AUTO,
-      CONFIG_MERGE_CONFLICT.KEEP_EXISTING,
-      configAuto
-    );
+    const configAutoCount = this._processConfigSource(CONFIG_SOURCE.AUTO, CONFIG_MERGE_CONFLICT.PRESERVE, configAuto);
 
     this.__isConfigProcessed = true;
     return {

--- a/src/feature-toggles.js
+++ b/src/feature-toggles.js
@@ -14,7 +14,7 @@
 
 const util = require("util");
 const pathlib = require("path");
-const { readFile } = require("fs");
+const fs = require("fs");
 const VError = require("verror");
 const yaml = require("yaml");
 const redis = require("./redis-adapter");
@@ -120,7 +120,7 @@ const SCOPE_PREFERENCE_ORDER_MASKS = [
 ];
 
 const cfEnv = CfEnv.getInstance();
-const readFileAsync = util.promisify(readFile);
+const readFileAsync = util.promisify(fs.readFile);
 let logger = new Logger(COMPONENT_NAME);
 
 /**
@@ -1726,6 +1726,7 @@ module.exports = {
   ENV,
   DEFAULT_REDIS_CHANNEL,
   DEFAULT_REDIS_KEY,
+  DEFAULT_CONFIG_FILEPATH,
   SCOPE_ROOT_KEY,
   FeatureToggles,
 

--- a/src/feature-toggles.js
+++ b/src/feature-toggles.js
@@ -744,13 +744,21 @@ class FeatureToggles {
    *
    * @param {InitializeOptions}  [options]
    */
-  async _initializeFeatures({ config: configRuntime, configFile: configFilepath, configAuto } = {}) {
+  async _initializeFeatures({
+    config: configRuntime,
+    configFile: configFilepath,
+    configFiles: configFilepaths,
+    configAuto,
+  } = {}) {
     if (this.__isInitialized) {
       return;
     }
 
     let configFromFile;
     try {
+      if (configFilepaths && (await tryPathReadable(DEFAULT_CONFIG_FILEPATH))) {
+        configFilepath = DEFAULT_CONFIG_FILEPATH;
+      }
       if (!configFilepath && (await tryPathReadable(DEFAULT_CONFIG_FILEPATH))) {
         configFilepath = DEFAULT_CONFIG_FILEPATH;
       }
@@ -779,10 +787,10 @@ class FeatureToggles {
           name: VERROR_CLUSTER_NAME,
           cause: err,
           info: {
-            ...(configAuto && { configAuto: JSON.stringify(configAuto) }),
-            ...(configFromFile && { configFromFile: JSON.stringify(configFromFile) }),
-            ...(configRuntime && { configRuntime: JSON.stringify(configRuntime) }),
             configFilepath,
+            ...(configRuntime && { configRuntime: JSON.stringify(configRuntime) }),
+            ...(configFromFile && { configFromFile: JSON.stringify(configFromFile) }),
+            ...(configAuto && { configAuto: JSON.stringify(configAuto) }),
           },
         },
         "initialization aborted, could not process configuration"

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -172,6 +172,7 @@ const activate = async () => {
   await toggles.initializeFeatures({
     config: envFeatureToggles?.config,
     configFile: envFeatureToggles?.configFile,
+    configFiles: envFeatureToggles?.configFiles,
     configAuto: ftsAutoConfig,
   });
 

--- a/test/integration-local/__snapshots__/feature-toggles.integration.test.js.snap
+++ b/test/integration-local/__snapshots__/feature-toggles.integration.test.js.snap
@@ -133,3 +133,43 @@ exports[`local integration test common config init getFeaturesKeys, getFeatureVa
   },
 }
 `;
+
+exports[`local integration test init init config works for runtime file auto simultaneously 1`] = `
+{
+  "test/feature_a": {
+    "config": {
+      "SOURCE": "RUNTIME",
+      "TYPE": "string",
+    },
+    "fallbackValue": "fallbackRuntimeA",
+  },
+  "test/feature_b": {
+    "config": {
+      "SOURCE": "RUNTIME",
+      "TYPE": "string",
+    },
+    "fallbackValue": "fallbackRuntimeB",
+  },
+  "test/feature_c": {
+    "config": {
+      "SOURCE": "FILE",
+      "TYPE": "string",
+    },
+    "fallbackValue": "fallbackFileC",
+  },
+  "test/feature_d": {
+    "config": {
+      "SOURCE": "FILE",
+      "TYPE": "string",
+    },
+    "fallbackValue": "fallbackFileD",
+  },
+  "test/feature_e": {
+    "config": {
+      "SOURCE": "AUTO",
+      "TYPE": "string",
+    },
+    "fallbackValue": "fallbackAutoE",
+  },
+}
+`;

--- a/test/integration-local/feature-toggles.integration.test.js
+++ b/test/integration-local/feature-toggles.integration.test.js
@@ -3,9 +3,9 @@
 //NOTE: if a local redis is running when these integration tests are performed, then they will not work. we rely on
 // and test only the local mode here.
 
-const fs = jest.requireActual("fs");
+const actualFs = jest.requireActual("fs");
 const mockReadFile = jest.fn();
-const mockAccess = jest.fn((cb) => cb());
+const mockAccess = jest.fn();
 jest.mock("fs", () => ({
   readFile: mockReadFile,
   access: mockAccess,
@@ -44,100 +44,119 @@ describe("local integration test", () => {
   });
 
   describe("init", () => {
-    test("init fails resolving for bad config paths", async () => {
-      mockReadFile.mockImplementationOnce(fs.readFile);
+    const configForRuntime = {
+      [FEATURE.A]: {
+        fallbackValue: "fallbackRuntimeA",
+        type: "string",
+      },
+      [FEATURE.B]: {
+        fallbackValue: "fallbackRuntimeB",
+        type: "string",
+      },
+    };
+    const configForFile = {
+      [FEATURE.C]: {
+        fallbackValue: "fallbackFileC",
+        type: "string",
+      },
+      [FEATURE.D]: {
+        fallbackValue: "fallbackFileD",
+        type: "string",
+      },
+    };
+    const configForAuto = {
+      [FEATURE.E]: {
+        fallbackValue: "fallbackAutoE",
+        type: "string",
+      },
+    };
+
+    test("init throws for non-existing filepaths", async () => {
+      mockReadFile.mockImplementationOnce(actualFs.readFile);
       await expect(toggles.initializeFeatures({ configFile: "fantasy_name" })).rejects.toMatchInlineSnapshot(
         `[FeatureTogglesError: initialization aborted, could not read config file: ENOENT: no such file or directory, open 'fantasy_name']`
       );
     });
 
+    test("init throws for existing filepaths with no supported extension", async () => {
+      mockReadFile.mockImplementationOnce((path, cb) => cb());
+      await expect(toggles.initializeFeatures({ configFile: "real_name.bad" })).rejects.toMatchInlineSnapshot(
+        `[FeatureTogglesError: initialization aborted, could not read config file: config filepath with unsupported extension, allowed extensions are .yaml and .json]`
+      );
+    });
+
     test("init fails processing for bad formats", async () => {
-      const badConfig = { ...config, bla: undefined };
+      const badConfig = { ...configForRuntime, bla: undefined };
       await expect(toggles.initializeFeatures({ config: badConfig })).rejects.toMatchInlineSnapshot(
         `[FeatureTogglesError: initialization aborted, could not process configuration: feature configuration is not an object]`
       );
     });
 
-    test("init consolidate config filepaths", async () => {});
-    test("init config conflict between runtime and file throws", async () => {});
-    test("init config conflict between file A and file B throws", async () => {});
-    test("init config conflict between file and auto preserves", async () => {});
+    test("init config conflict between runtime and file throws", async () => {
+      const configForConflict = {
+        ...configForRuntime,
+        ...configForFile,
+      };
+      mockReadFile.mockImplementationOnce((path, cb) => cb(null, Buffer.from(JSON.stringify(configForConflict))));
+
+      await expect(
+        toggles.initializeFeatures({ config: configForRuntime, configFile: "toggles.json" })
+      ).rejects.toMatchInlineSnapshot(
+        `[FeatureTogglesError: initialization aborted, could not process configuration: feature is configured twice]`
+      );
+    });
+
+    test("init config conflict between file A and file B throws", async () => {
+      mockReadFile.mockImplementationOnce((path, cb) => cb(null, Buffer.from(JSON.stringify(configForFile))));
+      mockReadFile.mockImplementationOnce((path, cb) => cb(null, Buffer.from(JSON.stringify(configForFile))));
+      await expect(
+        toggles.initializeFeatures({ configFiles: ["toggles-1.json", "toggles-2.json"] })
+      ).rejects.toMatchInlineSnapshot(
+        `[FeatureTogglesError: initialization aborted, could not process configuration: feature is configured twice]`
+      );
+    });
+
+    test("init config conflict between file and auto preserves", async () => {
+      const firstEntry = Object.entries(configForFile)[0];
+      const configForConflict = Object.fromEntries(
+        [firstEntry].map(([key, value]) => [key, { type: "number", fallbackValue: 0 }])
+      );
+      mockReadFile.mockImplementationOnce((filepath, callback) =>
+        callback(null, Buffer.from(JSON.stringify(configForFile)))
+      );
+      await expect(
+        toggles.initializeFeatures({ configFile: "toggles.json", configAuto: configForConflict })
+      ).resolves.toBeDefined();
+      expect(toggles.getFeatureInfo(firstEntry[0])).toMatchInlineSnapshot(`
+        {
+          "config": {
+            "SOURCE": "FILE",
+            "TYPE": "string",
+          },
+          "fallbackValue": "fallbackFileC",
+        }
+      `);
+    });
+
+    test("init config works for runtime file auto simultaneously", async () => {
+      mockReadFile.mockImplementationOnce((filepath, callback) =>
+        callback(null, Buffer.from(JSON.stringify(configForFile)))
+      );
+
+      await expect(
+        toggles.initializeFeatures({ config: configForRuntime, configFile: "toggles.json", configAuto: configForAuto })
+      ).resolves.toBeDefined();
+      expect(toggles.getFeaturesInfos()).toMatchSnapshot();
+
+      expect(featureTogglesLoggerSpy.info).toHaveBeenCalledTimes(1);
+      expect(featureTogglesLoggerSpy.info.mock.calls[0]).toMatchInlineSnapshot(`
+        [
+          "finished initialization of "unicorn" with 5 feature toggles (2 runtime, 2 file, 1 auto) using NO_REDIS",
+        ]
+      `);
+    });
 
     // TODO test for custom validation code from two config files with CONFIG_DIR!
-
-    // test("init config precedence", async () => {
-    //   const configForRuntime = {
-    //     [FEATURE.A]: {
-    //       fallbackValue: "fallbackRuntimeA",
-    //       type: "string",
-    //     },
-    //     [FEATURE.B]: {
-    //       fallbackValue: "fallbackRuntimeB",
-    //       type: "string",
-    //     },
-    //   };
-    //   const configForFile = {
-    //     [FEATURE.C]: {
-    //       fallbackValue: "fallbackFileC",
-    //       type: "string",
-    //     },
-    //   };
-    //   const configForAuto = {
-    //     [FEATURE.D]: {
-    //       fallbackValue: "fallbackAutoD",
-    //       type: "string",
-    //     },
-    //   };
-    //   mockReadFile.mockImplementationOnce((filepath, callback) =>
-    //     callback(null, Buffer.from(JSON.stringify(configForFile)))
-    //   );
-    //
-    //   await toggles.initializeFeatures({
-    //     config: configForRuntime,
-    //     configFile: "somePath.json",
-    //     configAuto: configForAuto,
-    //   });
-    //   expect(toggles.getFeaturesInfos()).toMatchInlineSnapshot(`
-    //     {
-    //       "test/feature_a": {
-    //         "config": {
-    //           "SOURCE": "RUNTIME",
-    //           "TYPE": "string",
-    //         },
-    //         "fallbackValue": "fallbackRuntimeA",
-    //       },
-    //       "test/feature_b": {
-    //         "config": {
-    //           "SOURCE": "RUNTIME",
-    //           "TYPE": "string",
-    //         },
-    //         "fallbackValue": "fallbackRuntimeB",
-    //       },
-    //       "test/feature_c": {
-    //         "config": {
-    //           "SOURCE": "FILE",
-    //           "TYPE": "string",
-    //         },
-    //         "fallbackValue": "fallbackFileC",
-    //       },
-    //       "test/feature_d": {
-    //         "config": {
-    //           "SOURCE": "AUTO",
-    //           "TYPE": "string",
-    //         },
-    //         "fallbackValue": "fallbackAutoD",
-    //       },
-    //     }
-    //   `);
-    //
-    //   expect(featureTogglesLoggerSpy.info.mock.calls).toMatchInlineSnapshot(`
-    //     [
-    //       [
-    //         "finished initialization of "unicorn" with 4 feature toggles (2 runtime, 1 file, 1 auto) using NO_REDIS",
-    //       ],
-    //     ]
-    //   `);
-    // });
   });
 
   describe("validations", () => {

--- a/test/integration-local/feature-toggles.integration.test.js
+++ b/test/integration-local/feature-toggles.integration.test.js
@@ -3,7 +3,7 @@
 //NOTE: if a local redis is running when these integration tests are performed, then they will not work. we rely on
 // and test only the local mode here.
 
-const actualFs = jest.requireActual("fs");
+const fsActual = jest.requireActual("fs");
 const mockReadFile = jest.fn();
 const mockAccess = jest.fn();
 jest.mock("fs", () => ({
@@ -72,7 +72,7 @@ describe("local integration test", () => {
     };
 
     test("init throws for non-existing filepaths", async () => {
-      mockReadFile.mockImplementationOnce(actualFs.readFile);
+      mockReadFile.mockImplementationOnce(fsActual.readFile);
       await expect(toggles.initializeFeatures({ configFile: "fantasy_name" })).rejects.toMatchInlineSnapshot(
         `[FeatureTogglesError: initialization aborted, could not read config file: ENOENT: no such file or directory, open 'fantasy_name']`
       );

--- a/test/integration-local/feature-toggles.integration.test.js
+++ b/test/integration-local/feature-toggles.integration.test.js
@@ -58,95 +58,86 @@ describe("local integration test", () => {
       );
     });
 
-    test("init config precedence", async () => {
-      const configForRuntime = {
-        [FEATURE.A]: {
-          fallbackValue: "fallbackRuntimeA",
-          type: "string",
-        },
-        [FEATURE.B]: {
-          fallbackValue: "fallbackRuntimeB",
-          type: "string",
-        },
-      };
-      const configForFile = {
-        [FEATURE.A]: {
-          fallbackValue: "fallbackFileA",
-          type: "string",
-        },
-        [FEATURE.C]: {
-          fallbackValue: "fallbackFileC",
-          type: "string",
-        },
-      };
-      const configForAuto = {
-        [FEATURE.A]: {
-          fallbackValue: "fallbackAutoA",
-          type: "string",
-        },
-        [FEATURE.B]: {
-          fallbackValue: "fallbackAutoB",
-          type: "string",
-        },
-        [FEATURE.C]: {
-          fallbackValue: "fallbackAutoC",
-          type: "string",
-        },
-        [FEATURE.D]: {
-          fallbackValue: "fallbackAutoD",
-          type: "string",
-        },
-      };
-      mockReadFile.mockImplementationOnce((filepath, callback) =>
-        callback(null, Buffer.from(JSON.stringify(configForFile)))
-      );
+    test("init consolidate config filepaths", async () => {});
+    test("init config conflict between runtime and file throws", async () => {});
+    test("init config conflict between file A and file B throws", async () => {});
+    test("init config conflict between file and auto preserves", async () => {});
 
-      await toggles.initializeFeatures({
-        config: configForRuntime,
-        configFile: "somePath.json",
-        configAuto: configForAuto,
-      });
-      expect(toggles.getFeaturesInfos()).toMatchInlineSnapshot(`
-        {
-          "test/feature_a": {
-            "config": {
-              "SOURCE": "RUNTIME",
-              "TYPE": "string",
-            },
-            "fallbackValue": "fallbackRuntimeA",
-          },
-          "test/feature_b": {
-            "config": {
-              "SOURCE": "RUNTIME",
-              "TYPE": "string",
-            },
-            "fallbackValue": "fallbackRuntimeB",
-          },
-          "test/feature_c": {
-            "config": {
-              "SOURCE": "FILE",
-              "TYPE": "string",
-            },
-            "fallbackValue": "fallbackFileC",
-          },
-          "test/feature_d": {
-            "config": {
-              "SOURCE": "AUTO",
-              "TYPE": "string",
-            },
-            "fallbackValue": "fallbackAutoD",
-          },
-        }
-      `);
+    // TODO test for custom validation code from two config files with CONFIG_DIR!
 
-      expect(featureTogglesLoggerSpy.info.mock.calls).toMatchInlineSnapshot(`
-        [
-          [
-            "finished initialization of "unicorn" with 4 feature toggles (2 runtime, 1 file, 1 auto) using NO_REDIS",
-          ],
-        ]
-      `);
-    });
+    // test("init config precedence", async () => {
+    //   const configForRuntime = {
+    //     [FEATURE.A]: {
+    //       fallbackValue: "fallbackRuntimeA",
+    //       type: "string",
+    //     },
+    //     [FEATURE.B]: {
+    //       fallbackValue: "fallbackRuntimeB",
+    //       type: "string",
+    //     },
+    //   };
+    //   const configForFile = {
+    //     [FEATURE.C]: {
+    //       fallbackValue: "fallbackFileC",
+    //       type: "string",
+    //     },
+    //   };
+    //   const configForAuto = {
+    //     [FEATURE.D]: {
+    //       fallbackValue: "fallbackAutoD",
+    //       type: "string",
+    //     },
+    //   };
+    //   mockReadFile.mockImplementationOnce((filepath, callback) =>
+    //     callback(null, Buffer.from(JSON.stringify(configForFile)))
+    //   );
+    //
+    //   await toggles.initializeFeatures({
+    //     config: configForRuntime,
+    //     configFile: "somePath.json",
+    //     configAuto: configForAuto,
+    //   });
+    //   expect(toggles.getFeaturesInfos()).toMatchInlineSnapshot(`
+    //     {
+    //       "test/feature_a": {
+    //         "config": {
+    //           "SOURCE": "RUNTIME",
+    //           "TYPE": "string",
+    //         },
+    //         "fallbackValue": "fallbackRuntimeA",
+    //       },
+    //       "test/feature_b": {
+    //         "config": {
+    //           "SOURCE": "RUNTIME",
+    //           "TYPE": "string",
+    //         },
+    //         "fallbackValue": "fallbackRuntimeB",
+    //       },
+    //       "test/feature_c": {
+    //         "config": {
+    //           "SOURCE": "FILE",
+    //           "TYPE": "string",
+    //         },
+    //         "fallbackValue": "fallbackFileC",
+    //       },
+    //       "test/feature_d": {
+    //         "config": {
+    //           "SOURCE": "AUTO",
+    //           "TYPE": "string",
+    //         },
+    //         "fallbackValue": "fallbackAutoD",
+    //       },
+    //     }
+    //   `);
+    //
+    //   expect(featureTogglesLoggerSpy.info.mock.calls).toMatchInlineSnapshot(`
+    //     [
+    //       [
+    //         "finished initialization of "unicorn" with 4 feature toggles (2 runtime, 1 file, 1 auto) using NO_REDIS",
+    //       ],
+    //     ]
+    //   `);
+    // });
   });
 
   describe("validations", () => {

--- a/test/integration-local/feature-toggles.integration.test.js
+++ b/test/integration-local/feature-toggles.integration.test.js
@@ -119,7 +119,7 @@ describe("local integration test", () => {
     test("init config conflict between file and auto preserves", async () => {
       const firstEntry = Object.entries(configForFile)[0];
       const configForConflict = Object.fromEntries(
-        [firstEntry].map(([key, value]) => [key, { type: "number", fallbackValue: 0 }])
+        [firstEntry].map(([key]) => [key, { type: "number", fallbackValue: 0 }])
       );
       mockReadFile.mockImplementationOnce((filepath, callback) =>
         callback(null, Buffer.from(JSON.stringify(configForFile)))

--- a/test/integration-local/feature-toggles.integration.test.js
+++ b/test/integration-local/feature-toggles.integration.test.js
@@ -322,7 +322,7 @@ describe("local integration test", () => {
       expect(mockValidator1).toHaveBeenCalledTimes(1);
       expect(mockValidator1).toHaveBeenCalledWith("fallback1", undefined, undefined);
       expect(mockValidator2).toHaveBeenCalledTimes(1);
-      expect(mockValidator1).toHaveBeenCalledWith("fallback2", undefined, undefined);
+      expect(mockValidator2).toHaveBeenCalledWith("fallback2", undefined, undefined);
     });
   });
 


### PR DESCRIPTION
TODO:

- [x] concept for dealing with auto config settings that conflict with configured configs. should definitely not take precedence, but also not lead to errors/exceptions
- [x] internal info field for configFilepath => this is good information at runtime, and we can use it for good error messages/infos on duplicate exceptions
- [x] tests for new initializataion behavior
- [x] tests for duplicate exceptions and error messages/infos