### PR TITLE
change default service user role to internal-user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
-- cds-plugin: change default access role to `internal-user` (fixes #90).
+- cds-plugin: change default service access role to `internal-user` (fixes #90).
 
 ## v1.2.3 - 2025-02-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## v1.2.4 - tbd
 
+### Changed
+
+- cds-plugin: change default access role to `internal-user` (fixes #90).
+
 ## v1.2.3 - 2025-02-05
 
 ### Added

--- a/docs/plugin/index.md
+++ b/docs/plugin/index.md
@@ -37,7 +37,7 @@ all of them the same unique name. See
 
 _serviceAccessRoles_, _readAccessRoles_, _writeAccessRoles_, _adminAccessRoles_<br>
 By default the `FeatureService` read and write endpoints are accessible only to users with the CAP pseudo-role
-[system-user](https://cap.cloud.sap/docs/guides/authorization#pseudo-roles). Different projects have their own access role preferences, so this setting allows them to set a
+[internal-user](https://cap.cloud.sap/docs/guides/security/authorization#pseudo-roles). Different projects have their own access role preferences, so this setting allows them to set a
 list of strings, which represent the roles required to access the service. For details see [@requires](https://cap.cloud.sap/docs/guides/authorization#requires).
 
 It will usually be sufficient to set the `serviceAccessRoles` configuration, which covers both the read and write

--- a/docs/plugin/index.md
+++ b/docs/plugin/index.md
@@ -38,7 +38,7 @@ all of them the same unique name. See
 _serviceAccessRoles_, _readAccessRoles_, _writeAccessRoles_, _adminAccessRoles_<br>
 By default the `FeatureService` read and write endpoints are accessible only to users with the CAP pseudo-role
 [internal-user](https://cap.cloud.sap/docs/guides/security/authorization#pseudo-roles). Different projects have their own access role preferences, so this setting allows them to set a
-list of strings, which represent the roles required to access the service. For details see [@requires](https://cap.cloud.sap/docs/guides/authorization#requires).
+list of strings, which represent the roles required to access the service. For details see [@requires](https://cap.cloud.sap/docs/guides/security/authorization#requires).
 
 It will usually be sufficient to set the `serviceAccessRoles` configuration, which covers both the read and write
 endpoints, but not the admin endpoints. If more discriminating access control is required, the `readAccessRoles` and

--- a/example-cap-server/.cdsrc.json
+++ b/example-cap-server/.cdsrc.json
@@ -6,8 +6,7 @@
         "system": {
           "tenant": "system",
           "password": "system",
-          "id": "system-user",
-          "roles": ["system-user"]
+          "roles": ["internal-user"]
         },
         "alice": {
           "tenant": "people",

--- a/example-cap-server/package.json
+++ b/example-cap-server/package.json
@@ -31,7 +31,7 @@
     "featureToggles": {
       "configFile": "./srv/feature/toggles.yaml",
       "serviceAccessRoles": [
-        "system-user",
+        "internal-user",
         "custom-role"
       ]
     }

--- a/src/service/feature-service.cds
+++ b/src/service/feature-service.cds
@@ -2,13 +2,13 @@
 
 @impl: '@cap-js-community/feature-toggle-library/src/service/feature-service.js'
 service FeatureService {
-    @(requires: ['system-user'])
+    @(requires: ['internal-user'])
     function state() returns {};
-    @(requires: ['system-user'])
+    @(requires: ['internal-user'])
     action redisRead() returns {};
 
     // NOTE: expects an object as input
-    @(requires: ['system-user'])
+    @(requires: ['internal-user'])
     @open
     action redisUpdate(newValues: {});
 

--- a/test/cds-test-project/.cdsrc.json
+++ b/test/cds-test-project/.cdsrc.json
@@ -6,8 +6,7 @@
         "system": {
           "tenant": "system",
           "password": "system",
-          "id": "system-user",
-          "roles": ["system-user"]
+          "roles": ["internal-user"]
         }
       }
     }


### PR DESCRIPTION
Fixes #90 

- `system-user` allow access to technical users from both Paas and Saas tenants, in contrast 
- `internal-user` allows access to technical users form only the Paas tenant.

So, `internal-user` makes more sense for our service default restrictions. For details, see
https://cap.cloud.sap/docs/guides/security/authorization#pseudo-roles
